### PR TITLE
간단한 User CRUD & 이메일, 닉네임 중복 검사 api

### DIFF
--- a/src/main/java/purcio/purcio/common/error/ExceptionController.java
+++ b/src/main/java/purcio/purcio/common/error/ExceptionController.java
@@ -8,6 +8,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import purcio.purcio.common.exception.NotFoundUserException;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.NoSuchElementException;

--- a/src/main/java/purcio/purcio/common/exception/EmailIsAlreadyExist.java
+++ b/src/main/java/purcio/purcio/common/exception/EmailIsAlreadyExist.java
@@ -1,0 +1,20 @@
+package purcio.purcio.common.exception;
+
+public class EmailIsAlreadyExist extends RuntimeException{
+
+    public EmailIsAlreadyExist() {
+        super();
+    }
+
+    public EmailIsAlreadyExist(String message) {
+        super(message);
+    }
+
+    public EmailIsAlreadyExist(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public EmailIsAlreadyExist(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/purcio/purcio/common/exception/NickNameIsAlreadyExist.java
+++ b/src/main/java/purcio/purcio/common/exception/NickNameIsAlreadyExist.java
@@ -1,0 +1,19 @@
+package purcio.purcio.common.exception;
+
+public class NickNameIsAlreadyExist extends RuntimeException{
+
+    public NickNameIsAlreadyExist() {
+    }
+
+    public NickNameIsAlreadyExist(String message) {
+        super(message);
+    }
+
+    public NickNameIsAlreadyExist(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NickNameIsAlreadyExist(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/purcio/purcio/common/exception/NotFoundUserException.java
+++ b/src/main/java/purcio/purcio/common/exception/NotFoundUserException.java
@@ -1,0 +1,20 @@
+package purcio.purcio.common.exception;
+
+public class NotFoundUserException extends RuntimeException{
+
+    public NotFoundUserException() {
+        super("존재하지 않는 사용자입니다.");
+    }
+
+    public NotFoundUserException(String message) {
+        super(message);
+    }
+
+    public NotFoundUserException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NotFoundUserException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/purcio/purcio/order/domain/Cart.java
+++ b/src/main/java/purcio/purcio/order/domain/Cart.java
@@ -1,5 +1,6 @@
 package purcio.purcio.order.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,6 +17,7 @@ import java.util.List;
 @Table(name = "cart")
 public class Cart extends BaseEntity {
 
+    @JsonIgnore
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;

--- a/src/main/java/purcio/purcio/order/domain/Order.java
+++ b/src/main/java/purcio/purcio/order/domain/Order.java
@@ -1,5 +1,6 @@
 package purcio.purcio.order.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,6 +19,7 @@ import java.util.List;
 @Table(name = "orders")
 public class Order extends BaseEntity {
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user; // 구매자

--- a/src/main/java/purcio/purcio/user/controller/UserController.java
+++ b/src/main/java/purcio/purcio/user/controller/UserController.java
@@ -3,33 +3,86 @@ package purcio.purcio.user.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import purcio.purcio.common.ResponseDTO;
-import purcio.purcio.user.dto.UserCreateReqDTO;
-import purcio.purcio.user.dto.UserUpdateReqDTO;
+import purcio.purcio.user.dto.user.UserCreateReqDTO;
+import purcio.purcio.user.dto.user.UserUpdateReqDTO;
 import purcio.purcio.user.service.UserService;
 
 @RestController
+@RequestMapping("/api/user")
 @RequiredArgsConstructor
 public class UserController {
 
     private final UserService userService;
 
-    @GetMapping("/api/user/{id}")
+    @GetMapping("/{id}")
     public ResponseDTO<Object> retrieveUser(@PathVariable Long id){
         return userService.retrieveUser(id);
     }
 
-    @GetMapping("/api/user")
+    @GetMapping("")
     public ResponseDTO<Object> retrieveUserList(){
         return userService.retrieveUserList();
     }
 
-    @PostMapping("/api/user")
+    @PostMapping("")
     public ResponseDTO<Object> createUser(@RequestBody UserCreateReqDTO userCreateReqDTO){
         return userService.createUser(userCreateReqDTO);
     }
 
-    @PutMapping("/api/user/{id}")
+    @PutMapping("/{id}")
     public ResponseDTO<Object> updateUser(@PathVariable Long id, @RequestBody UserUpdateReqDTO userUpdateReqDTO){
         return userService.updateUser(id, userUpdateReqDTO);
     }
+
+    /**
+     * 닉네임의 존재 여부를 알려줍니다.
+     * @param nickName
+     * @return boolean
+     */
+    @GetMapping("/isExist/nickname={nickName}")
+    public ResponseDTO<Object> isExistNickName(@PathVariable("nickName") String nickName){
+        ResponseDTO responseDTO;
+        if(userService.nickNameIsExist(nickName)) {
+            responseDTO = ResponseDTO.builder()
+                    .message("동일한 닉네임이 존재합니다.")
+                    .content(Boolean.TRUE)
+                    .build();
+        }
+
+        else {
+            responseDTO = ResponseDTO.builder()
+                    .message("동일한 닉네임이 존재하지 않습니다.")
+                    .content(Boolean.FALSE)
+                    .build();
+        }
+
+        return responseDTO;
+    }
+
+    /**
+     * 이메일의 존재 여부를 알려줍니다.
+     * @param email
+     * @return void
+     */
+    @GetMapping("/isExist/email={email}")
+    public ResponseDTO<Object> isExistEmail(@PathVariable("email") String email){
+
+        ResponseDTO responseDTO;
+
+        if(userService.emailIsExist(email)) {
+            responseDTO = ResponseDTO.builder()
+                    .message("이메일이 존재합니다.")
+                    .content(Boolean.TRUE)
+                    .build();
+        }
+        else{
+            responseDTO = ResponseDTO.builder()
+                    .message("이메일이 존재하지 않습니다.")
+                    .content(Boolean.FALSE)
+                    .build();
+        }
+        return responseDTO;
+    }
+
+
 }

--- a/src/main/java/purcio/purcio/user/domain/Address.java
+++ b/src/main/java/purcio/purcio/user/domain/Address.java
@@ -19,6 +19,13 @@ public class Address {
     private String street;
     private String zipcode;
 
+    public void updateAddress(Address address) {
+        if(address.city != null) this.city = address.city;
+        if(address.district != null) this.district = address.district;
+        if(address.street != null) this.street = address.street;
+        if(address.zipcode != null) this.zipcode = address.zipcode;
+    }
+
     @Builder
     public Address(String city, String district, String street, String zipcode) {
         this.city = city;

--- a/src/main/java/purcio/purcio/user/domain/User.java
+++ b/src/main/java/purcio/purcio/user/domain/User.java
@@ -23,7 +23,7 @@ import java.util.List;
 public class User extends BaseEntity {
 
     private String name;
-
+    private String password;
     @Column(nullable = false, unique = true)
     private String email;
 
@@ -60,29 +60,56 @@ public class User extends BaseEntity {
         return this.cart;
     }
 
-    @Builder
-    public User(String name, String email, String picture, String nickName, String phoneNumber, Integer age, String sex, Address address) {
-        this.name = name;
-        this.email = email;
-        this.picture = picture;
-        this.nickName = nickName;
-        this.phoneNumber = phoneNumber;
-        this.age = age;
-        this.sex = sex;
-        this.address = address;
+    /**
+     * 유저를 생성합니다.
+     * @param name 유저 이름
+     * @param email 유저 이메일 (not null)
+     * @param picture 프로필 사진
+     * @param nickName 닉네임
+     * @param phoneNumber 휴대폰번호
+     * @param age 나이
+     * @param sex 성별
+     * @param address 주소
+     * @return 생성된 유저의 객체
+     */
+    // TODO: set 함수를 통해 blank 값에 대한 처리 필요
+    public static User createUser(String name, String password, String email, String picture, String nickName, String phoneNumber, Integer age, String sex, Address address) {
+        User user = new User();
+        user.name = name;
+        user.password = password;
+        user.email = email;
+        user.picture = picture;
+        user.nickName = nickName;
+        user.phoneNumber = phoneNumber;
+        user.age = age;
+        user.sex = sex;
+        user.address = address;
+
+        return user;
     }
 
-    public void updateUser(String name, String email, String picture, String nickName, String phoneNumber, Integer age, String sex, Address address) {
-        if(this.name != null) this.name = name;
-        if(this.email != null) this.email = email;
-        if(this.picture != null) this.picture = picture;
-        if(this.nickName != null) this.nickName = nickName;
-        if(this.phoneNumber != null) this.phoneNumber = phoneNumber;
-        if(this.age != null) this.age = age;
-        if(this.sex != null) this.sex = sex;
-        if(this.address != null) this.address = address;
-
-        update();
+    /**
+     * 유저를 업데이트한다.
+     * 입력받은 값이 null이 아닐 경우에만 업데이트한다.
+     * @param name
+     * @param password
+     * @param picture
+     * @param nickName
+     * @param phoneNumber
+     * @param age
+     * @param sex
+     * @param address
+     */
+    public void updateUser(String name, String password, String picture, String nickName, String phoneNumber, Integer age, String sex, Address address) {
+        super.update();
+        if(name != null) this.name = name;
+        if(password != null) this.password = password;
+        if(picture != null) this.picture = picture;
+        if(nickName != null) this.nickName = nickName;
+        if(phoneNumber != null) this.phoneNumber = phoneNumber;
+        if(age != null) this.age = age;
+        if(sex != null) this.sex = sex;
+        if(address != null) this.address.updateAddress(address);
     }
 
 

--- a/src/main/java/purcio/purcio/user/dto/user/UserCreateReqDTO.java
+++ b/src/main/java/purcio/purcio/user/dto/user/UserCreateReqDTO.java
@@ -1,12 +1,15 @@
-package purcio.purcio.user.dto;
+package purcio.purcio.user.dto.user;
 
 import lombok.Data;
 import purcio.purcio.user.domain.Address;
 
+import javax.validation.constraints.NotBlank;
+
 @Data
-public class UserUpdateReqDTO {
+public class UserCreateReqDTO {
 
     private String name;
+    private String password;
     private String email;
     private String picture;
 
@@ -16,4 +19,5 @@ public class UserUpdateReqDTO {
     private String sex; // 성별
 
     private Address address; // 거주지
+
 }

--- a/src/main/java/purcio/purcio/user/dto/user/UserUpdateReqDTO.java
+++ b/src/main/java/purcio/purcio/user/dto/user/UserUpdateReqDTO.java
@@ -1,15 +1,13 @@
-package purcio.purcio.user.dto;
+package purcio.purcio.user.dto.user;
 
 import lombok.Data;
 import purcio.purcio.user.domain.Address;
 
-import javax.validation.constraints.NotBlank;
-
 @Data
-public class UserCreateReqDTO {
+public class UserUpdateReqDTO {
 
     private String name;
-    private String email;
+    private String password;
     private String picture;
 
     private String nickName; // 닉네임
@@ -18,5 +16,4 @@ public class UserCreateReqDTO {
     private String sex; // 성별
 
     private Address address; // 거주지
-
 }

--- a/src/main/java/purcio/purcio/user/repository/UserRepository.java
+++ b/src/main/java/purcio/purcio/user/repository/UserRepository.java
@@ -4,7 +4,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import purcio.purcio.user.domain.User;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    Optional<User> findUserByEmail(String name);
+    Optional<User> findUserByNickName(String nickName);
 }

--- a/src/main/java/purcio/purcio/user/service/UserService.java
+++ b/src/main/java/purcio/purcio/user/service/UserService.java
@@ -3,14 +3,16 @@ package purcio.purcio.user.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import purcio.purcio.common.exception.EmailIsAlreadyExist;
+import purcio.purcio.common.exception.NickNameIsAlreadyExist;
+import purcio.purcio.common.exception.NotFoundUserException;
 import purcio.purcio.user.domain.User;
 import purcio.purcio.common.ResponseDTO;
-import purcio.purcio.user.dto.UserCreateReqDTO;
-import purcio.purcio.user.dto.UserUpdateReqDTO;
+import purcio.purcio.user.dto.user.UserCreateReqDTO;
+import purcio.purcio.user.dto.user.UserUpdateReqDTO;
 import purcio.purcio.user.repository.UserRepository;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -38,18 +40,27 @@ public class UserService {
                 .build();
     }
 
+    /**
+     * 유저를 생성한다.
+     * @param userCreateReqDTO 등록 정보
+     * @return 생성된 유저의 아이디
+     */
     @Transactional
     public ResponseDTO<Object> createUser(UserCreateReqDTO userCreateReqDTO){
 
-        User user = User.builder()
-                .name(userCreateReqDTO.getName())
-                .email(userCreateReqDTO.getEmail())
-                .picture(userCreateReqDTO.getPicture())
-                .nickName(userCreateReqDTO.getNickName())
-                .phoneNumber(userCreateReqDTO.getPhoneNumber())
-                .age(userCreateReqDTO.getAge())
-                .address(userCreateReqDTO.getAddress())
-                .build();
+        if(emailIsExist(userCreateReqDTO.getEmail())) {
+            throw new EmailIsAlreadyExist("이미 존재하는 이메일입니다.");
+        }
+
+        if(nickNameIsExist(userCreateReqDTO.getNickName())){
+            throw new NickNameIsAlreadyExist("이미 존재하는 닉네임입니다.");
+        }
+
+        // TODO: password 암호화 작업 필요
+        User user = User.createUser(userCreateReqDTO.getName(), userCreateReqDTO.getPassword(), userCreateReqDTO.getEmail(),
+                userCreateReqDTO.getPicture(), userCreateReqDTO.getNickName(),
+                userCreateReqDTO.getPhoneNumber(), userCreateReqDTO.getAge(),
+                userCreateReqDTO.getSex(), userCreateReqDTO.getAddress());
 
         userRepository.save(user);
 
@@ -59,11 +70,20 @@ public class UserService {
                 .build();
     }
 
+    /** 유저를 변경한다.
+     * @param id 유저 아이디
+     * @param userUpdateReqDTO 변경 정보
+     * @return 변경된 유저의 아이디
+     */
     @Transactional
     public ResponseDTO<Object> updateUser(Long id, UserUpdateReqDTO userUpdateReqDTO){
-        User user = userRepository.findById(id).orElseThrow(NoSuchElementException::new);
+        User user = userRepository.findById(id).orElseThrow(NotFoundUserException::new);
 
-        user.updateUser(userUpdateReqDTO.getName(), userUpdateReqDTO.getEmail(),
+        if(nickNameIsExist(userUpdateReqDTO.getNickName())){
+            throw new NickNameIsAlreadyExist("이미 존재하는 닉네임입니다.");
+        }
+
+        user.updateUser(userUpdateReqDTO.getName(), userUpdateReqDTO.getPassword(),
                 userUpdateReqDTO.getPicture(), userUpdateReqDTO.getNickName(),
                 userUpdateReqDTO.getPhoneNumber(), userUpdateReqDTO.getAge(),
                 userUpdateReqDTO.getSex(), userUpdateReqDTO.getAddress());
@@ -76,9 +96,14 @@ public class UserService {
                 .build();
     }
 
+    /**
+     * 유저를 삭제한다.
+     * @param id
+     * @return 삭제된 유저의 아이디
+     */
     @Transactional
     public ResponseDTO<Object> deleteUser(Long id){
-        User user = userRepository.findById(id).orElseThrow(NoSuchElementException::new);
+        User user = userRepository.findById(id).orElseThrow(NotFoundUserException::new);
 
         userRepository.delete(user);
 
@@ -86,6 +111,30 @@ public class UserService {
                 .message("유저 삭제가 완료되었습니다.")
                 .content(user.getId())
                 .build();
+    }
+
+    /**
+     * 현재 해당 이메일이 존재하는지 판별한다.
+     * @param email
+     * @return 존재한다면 TRUE & 없다면 False
+     */
+    @Transactional(readOnly = true)
+    public Boolean emailIsExist(String email){
+        User user = userRepository.findUserByEmail(email).orElse(null);
+
+        return user != null ? Boolean.TRUE : Boolean.FALSE;
+    }
+
+    /**
+     * 해당 닉네임이 존재하는지 판별한다.
+     * @param nickName
+     * @return 존재한다면 TRUE & 없다면 FALSE
+     */
+    @Transactional(readOnly = true)
+    public Boolean nickNameIsExist(String nickName){
+        User user = userRepository.findUserByNickName(nickName).orElse(null);
+
+        return user != null ? Boolean.TRUE : Boolean.FALSE;
     }
 
 


### PR DESCRIPTION
added crud of user
- 유저 CRUD
- 중복 이메일 & 중복 닉네임 에러 클래스 생성
   - 가입 & 수정 시 예외 처리
- 중복 이메일 & 닉네임 판단 api 생성
- Json 직렬화 과정에서 양방향 무한참조 이슈 해결
   - Cart, Order Entity의 User에 @JsonIgnore 어노테이션
  